### PR TITLE
Remove is_user_active call

### DIFF
--- a/app/Http/Controllers/BookmarksController.php
+++ b/app/Http/Controllers/BookmarksController.php
@@ -11,7 +11,6 @@ class BookmarksController extends Controller
     public function getInstapaper() {
         $instapaper = new Instapaper();
         $instapaper->login();
-        $instapaper->is_user_active();
         return $instapaper;
     }
 


### PR DESCRIPTION
No longer needed because API does not require an active subscription any longer.

Fixes #1